### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,4 +3,4 @@ Zenbership Database Migrations
 
 This repo is designed to hold all database migrations for new versions of Zenbership.
 
-For information on how to use these files, and how to update the program in general, please consult our [online documentation](http://documentation.zenbership.com/Updating-Zenbership).
+For information on how to use these files, and how to update the program in general, please consult our [online documentation](http://documentation.zenbership.com/Home/Updating-Zenbership).


### PR DESCRIPTION
URL for Updating Zenbership changed. Former link was redirected to the home page of Product Manual instead of update instructions.